### PR TITLE
[lbry] fee: update `getinfo.paytxfee` to 0

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -649,7 +649,7 @@ func getInfo(icmd interface{}, w *wallet.Wallet, chainClient *chain.RPCClient) (
 	info.WalletVersion = int32(waddrmgr.LatestMgrVersion)
 	info.Balance = bal.ToBTC()
 	info.Staked = staked.ToBTC()
-	info.PaytxFee = float64(txrules.DefaultRelayFeePerKb)
+	info.PaytxFee = 0
 	// We don't set the following since they don't make much sense in the
 	// wallet architecture:
 	//  - unlocked_until


### PR DESCRIPTION
This is a hack fix to unblock lbrypool.net.

The paytxfee in lbcwallet is actually not being used anywhere, and is
hardcoded to DefaultRelayFee, which is 1000. Lbrycrd sets default to 0.

Also, since the paytxfee is not actually used/implemented, the
'settxfee' RPC is also