### PR TITLE
import: add support for watchonly addresses/pubkeys [WIP]

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -920,6 +920,9 @@ func getReceivedByAccount(icmd interface{}, w *wallet.Wallet) (interface{}, erro
 		return nil, err
 	}
 	acctIndex := int(account)
+	if account == waddrmgr.ImportedWatchonlyAddrAccount {
+		acctIndex = len(results) - 2
+	}
 	if account == waddrmgr.ImportedAddrAccount {
 		acctIndex = len(results) - 1
 	}
@@ -1692,7 +1695,7 @@ func sendToAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 	}
 
 	// sendtoaddress always spends from the default account, this matches bitcoind
-	return sendPairs(w, pairs, waddrmgr.KeyScopeBIP0044, waddrmgr.DefaultAccountNum, 1,
+	return sendPairs(w, pairs, waddrmgr.KeyScopeBIP0084, waddrmgr.DefaultAccountNum, 1,
 		txrules.DefaultRelayFeePerKb)
 }
 

--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -102,7 +102,8 @@ func isReservedAccountName(name string) bool {
 // isReservedAccountNum returns true if the account number is reserved.
 // Reserved accounts may not be renamed.
 func isReservedAccountNum(acct uint32) bool {
-	return acct == ImportedAddrAccount
+	return acct == ImportedAddrAccount ||
+		acct == ImportedWatchonlyAddrAccount
 }
 
 // ScryptOptions is used to hold the scrypt parameters needed when deriving new
@@ -428,6 +429,7 @@ func (m *Manager) IsWatchOnlyAccount(ns walletdb.ReadBucket, keyScope KeyScope,
 	if account == ImportedAddrAccount {
 		return false, nil
 	}
+
 	if account == ImportedWatchonlyAddrAccount {
 		return true, nil
 	}
@@ -1785,10 +1787,23 @@ func createManagerKeyScope(ns walletdb.ReadWriteBucket,
 		return err
 	}
 
-	return putDefaultAccountInfo(
+	err = putDefaultAccountInfo(
 		ns, &scope, ImportedAddrAccount, nil, nil, 0, 0,
 		ImportedAddrAccountName,
 	)
+	if err != nil {
+		return err
+	}
+
+	err = putDefaultAccountInfo(
+		ns, &scope, ImportedWatchonlyAddrAccount, nil, nil, 0, 0,
+		ImportedWatchonlyAddrAccountName,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Create creates a new address manager in the given namespace.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2457,8 +2457,8 @@ func (w *Wallet) AccountBalances(scope waddrmgr.KeyScope,
 			results[i].AccountNumber = uint32(i)
 			results[i].AccountName = accountName
 		}
+		results[len(results)-2].AccountName = waddrmgr.ImportedAddrAccountName
 		results[len(results)-1].AccountNumber = waddrmgr.ImportedAddrAccount
-		results[len(results)-1].AccountName = waddrmgr.ImportedAddrAccountName
 
 		// Fetch all unspent outputs, and iterate over them tallying each
 		// account's balance where the output script pays to an account address
@@ -2488,6 +2488,8 @@ func (w *Wallet) AccountBalances(scope waddrmgr.KeyScope,
 				continue
 			}
 			switch {
+			case outputAcct == waddrmgr.ImportedWatchonlyAddrAccount:
+				results[len(results)-2].AccountBalance += output.Amount
 			case outputAcct == waddrmgr.ImportedAddrAccount:
 				results[len(results)-1].AccountBalance += output.Amount
 			case outputAcct > lastAcct:
@@ -3080,6 +3082,9 @@ func (w *Wallet) TotalReceivedForAccounts(scope waddrmgr.KeyScope,
 					}
 					if err == nil {
 						acctIndex := int(outputAcct)
+						if outputAcct == waddrmgr.ImportedWatchonlyAddrAccount {
+							acctIndex = len(results) - 2
+						}
 						if outputAcct == waddrmgr.ImportedAddrAccount {
 							acctIndex = len(results) - 1
 						}


### PR DESCRIPTION
Fix #18 

Previously, lbcwallet treats all imported keys as "watchonly".
We had a hotfix to reverse it treating all imported as "non-watchonly",
which is actually the use cases of known users. (exchanges/pools)

This patch aims to addresses this issue more properly by supporting
"imported-watchonly" accounts, which managed all imported addresses
and public keys.