### PR TITLE
Fix race condition after reorg

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -245,7 +245,7 @@ func (w *Wallet) disconnectBlock(dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) 
 			if err != nil {
 				return err
 			}
-			b.Hash = *hash
+			bs.Hash = *hash
 
 			client := w.ChainClient()
 			header, err := client.GetBlockHeader(hash)


### PR DESCRIPTION
Fix #28 

This PR solves to issues:

1. The rollback code, which handles disconnected blocks, did not save the hash to the `w.manager.SyncedTo` status.  Seems like a bug caused by a typo - `b.hash vs bs.Hash`

2.  Handle corner cases where the chain has reorged to a lower height than the wallet had synced to. 
This could happen if the chain has reorged to a shorter chain with difficulty greater than the current main chain.
The wallet won't be able to sync before the reorged chain grows past the previous main chain's height.